### PR TITLE
Fixes for two search result highlighting bugs

### DIFF
--- a/Keyterms-Client/src/config.js
+++ b/Keyterms-Client/src/config.js
@@ -27,4 +27,4 @@
 
 var mailto = 'example@email.com';
 
-var apiUrl = 'http://localhost:4000/';
+var apiUrl = 'myServerLocation';

--- a/Keyterms-Client/src/config.js
+++ b/Keyterms-Client/src/config.js
@@ -27,4 +27,4 @@
 
 var mailto = 'example@email.com';
 
-var apiUrl = 'myServerLocation';
+var apiUrl = 'http://localhost:4000/';

--- a/Keyterms-Client/src/resources/templates/widgets/displayEntryList.html
+++ b/Keyterms-Client/src/resources/templates/widgets/displayEntryList.html
@@ -31,12 +31,12 @@
         <div class="col-xs-11">
             <div class="labels-container">
                 <span ng-repeat="label in entry.terms | filter: {isLabel: true}" >
-                    <span ng-if="$parent.$parent.isTextSearch" ng-bind-html="::label.termText"></span>
-                    <span ng-if="!$parent.$parent.isTextSearch">{{label.termText}}</span>
+                    <span ng-if="!!label.highlightTermText" ng-bind-html="::label.highlightTermText"></span>
+                    <span ng-if="!label.highlightTermText">{{label.termText}}</span>
                 </span>
             </div>
             <div class="terms">
-                <span ng-repeat="term in entry.terms | filter: { src : '!nlp', isLabel: false }" ><span ng-if="!$parent.$parent.isTextSearch">{{::term.termText}}</span><span ng-bind-html="::term.termText" ng-if="$parent.$parent.isTextSearch"></span>{{::$last ? '' : ', ' }} </span>
+                <span ng-repeat="term in entry.terms | filter: { src : '!nlp', isLabel: false }" ><span ng-if="!term.highlightTermText">{{::term.termText}}</span><span ng-bind-html="::term.highlightTermText" ng-if="!!term.highlightTermText"></span>{{::$last ? '' : ', ' }} </span>
             </div>
             <div class="entry-info">
                 <span class="org-name"   tooltip-placement="bottom" uib-tooltip="Organization: {{::entry.org.name}}"><i class="fa fa-sitemap"></i> {{::entry.org.name}}</span>

--- a/Keyterms-Server/dist/app/api/routes/search.js
+++ b/Keyterms-Server/dist/app/api/routes/search.js
@@ -144,12 +144,11 @@ var processMongoQuery = function (entries, entryDict) {
 
 			var termId = term._id.toString();
 
+			// If we've got a highlight text, populate that onto the term itself
 			if (!!entryDict[entry._id].highlightTermText[termId]) {
-				term.termText = entryDict[entry._id].highlightTermText[termId];
-			} else {
-				// Other terms must have their text escaped manually
-				term.termText = escape(term.termText);
+				term.highlightTermText = entryDict[entry._id].highlightTermText[termId];
 			}
+
 		});
 	});
 
@@ -242,7 +241,8 @@ var executeDefaultSearch = function (req) {
 						if(!entryIds[key].highlightTermText.hasOwnProperty(termKey)) continue;
 
 						// Find/Replace the {{{em}}} tags that indicate a search match from elastic search
-						entryIds[key].highlightTermText[termKey] = entryIds[key].highlightTermText[termKey].replace(new RegExp('{{{em}}}', 'g') , '<b class="search-hit">');
+						// Escape HTML characters before the first regex replace
+						entryIds[key].highlightTermText[termKey] = escape(entryIds[key].highlightTermText[termKey]).replace(new RegExp('{{{em}}}', 'g') , '<b class="search-hit">');
 						entryIds[key].highlightTermText[termKey] = entryIds[key].highlightTermText[termKey].replace(new RegExp('{{{/em}}}', 'g'), '</b>');
 					}
 				}

--- a/Keyterms-Server/dist/app/api/routes/search.js
+++ b/Keyterms-Server/dist/app/api/routes/search.js
@@ -242,8 +242,8 @@ var executeDefaultSearch = function (req) {
 						if(!entryIds[key].highlightTermText.hasOwnProperty(termKey)) continue;
 
 						// Find/Replace the {{{em}}} tags that indicate a search match from elastic search
-						entryIds[key].highlightTermText[termKey] = entryIds[key].highlightTermText[termKey].replace('{{{em}}}', '<b class="search-hit">');
-						entryIds[key].highlightTermText[termKey] = entryIds[key].highlightTermText[termKey].replace('{{{/em}}}', '</b>');
+						entryIds[key].highlightTermText[termKey] = entryIds[key].highlightTermText[termKey].replace(new RegExp('{{{em}}}', 'g') , '<b class="search-hit">');
+						entryIds[key].highlightTermText[termKey] = entryIds[key].highlightTermText[termKey].replace(new RegExp('{{{/em}}}', 'g'), '</b>');
 					}
 				}
 				return processMongoQuery(entries, entryIds);


### PR DESCRIPTION
Resolves:
1. {{{em}}} tags in double-hit search results
2. html showing in Nominate Delete terms popup